### PR TITLE
feat: Re-added playback and page controls update

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2026 Jordan Brotherton
+Copyright (c) 2026 UF Open Source Club
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/assets/base_ux/theme.tres
+++ b/assets/base_ux/theme.tres
@@ -49,6 +49,9 @@ border_width_bottom = 2
 border_color = Color(0, 0.5803922, 1, 1)
 anti_aliasing = false
 
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_m8jh7"]
+bg_color = Color(0.1497609, 0.28717783, 0.44712496, 0.39215687)
+
 [resource]
 Button/colors/font_color = Color(1, 1, 1, 1)
 Button/styles/disabled = SubResource("StyleBoxFlat_6j8ly")
@@ -57,3 +60,4 @@ Button/styles/hover_pressed = SubResource("StyleBoxFlat_dtpf4")
 Button/styles/normal = SubResource("StyleBoxFlat_31loe")
 Button/styles/pressed = SubResource("StyleBoxFlat_pchdo")
 ItemList/styles/panel = SubResource("StyleBoxFlat_xeq2n")
+Panel/styles/panel = SubResource("StyleBoxFlat_m8jh7")

--- a/system/playback/playback_manager.gd
+++ b/system/playback/playback_manager.gd
@@ -1,0 +1,18 @@
+class_name PlaybackManager
+extends Node
+
+var is_playing: bool = false
+
+var _project: Project
+var _timer: float = 0.0
+
+func attach_project(project: Project) -> void:
+	_project = project
+
+func _process(delta: float) -> void:
+	if is_playing:
+		var frame_time = (1.0 / max(_project.framerate, 1))
+		_timer += delta
+		if _timer >= frame_time:
+			_project.next_page(true)
+			_timer -= frame_time

--- a/system/playback/playback_manager.gd.uid
+++ b/system/playback/playback_manager.gd.uid
@@ -1,0 +1,1 @@
+uid://dg2xr82qtamwp

--- a/views/editor/containers/page_controls/page_controls.gd
+++ b/views/editor/containers/page_controls/page_controls.gd
@@ -1,10 +1,21 @@
 extends Node
 
-signal framerate_change(new_fr: float)
 signal play_toggle
 
 signal load_call
 signal save_call
+
+@export var next_page_button: Button
+@export var page_count_label: Label
+@export var prev_page_button: Button
+
+@export var framerate_slider: Slider
+@export var framerate_label: Label
+
+@export var play_button: Button
+
+@export var save_button: Button
+@export var load_button: Button
 
 var is_playing = false
 
@@ -12,26 +23,32 @@ var _project: Project
 
 func attach_project(project: Project):
 	_project = project
+	_project.new_current_page.connect(_update_view)
+
+func _update_view(_page: Page) -> void:
+	framerate_slider.value = _project.framerate
+	framerate_label.text = str(int(_project.framerate))
+	page_count_label.text = "%d/%d" % [_project._current_frame + 1, _project.frames.size()]
 
 func _on_next_button_pressed() -> void:
-	if(_project):
+	if _project:
 		_project.next_page(false)
 
 func _on_prev_button_pressed() -> void:
-	if(_project):
+	if _project:
 		_project.prev_page()
 
 func _on_play_pressed() -> void:
 	play_toggle.emit()
 	is_playing = !is_playing
 
-	$HBoxContainer/PlayButton.text = "Pause" if is_playing else "Play"
-	$HBoxContainer/NextButton.disabled = ! $HBoxContainer/NextButton.disabled
-	$HBoxContainer/PrevButton.disabled = ! $HBoxContainer/PrevButton.disabled
+	play_button.text = "Pause" if is_playing else "Play"
+	next_page_button.disabled = ! next_page_button.disabled
+	prev_page_button.disabled = ! prev_page_button.disabled
 
 func _on_slider_value_changed(value: float) -> void:
-	$HBoxContainer/HBoxContainer/Label.text = str(value)
-	framerate_change.emit(value)
+	framerate_label.text = str(int(value))
+	_project.framerate = value
 
 func _on_save_button_pressed() -> void:
 	save_call.emit()

--- a/views/editor/containers/page_controls/page_controls.tscn
+++ b/views/editor/containers/page_controls/page_controls.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" uid="uid://fduhdjv3ekah" path="res://views/editor/containers/page_controls/page_controls.gd" id="1_8tmw1"]
 
-[node name="PageControls" type="Control" unique_id=352413597]
+[node name="PageControls" type="Control" unique_id=352413597 node_paths=PackedStringArray("next_page_button", "page_count_label", "prev_page_button", "framerate_slider", "framerate_label", "play_button", "save_button", "load_button")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -10,8 +10,24 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_8tmw1")
+next_page_button = NodePath("Panel/HBoxContainer/NextButton")
+page_count_label = NodePath("Panel/HBoxContainer/PageCount")
+prev_page_button = NodePath("Panel/HBoxContainer/PrevButton")
+framerate_slider = NodePath("Panel/HBoxContainer/FRContainer/FRSlider")
+framerate_label = NodePath("Panel/HBoxContainer/FRContainer/Framerate")
+play_button = NodePath("Panel/HBoxContainer/PlayButton")
+save_button = NodePath("Panel/HBoxContainer/SaveButton")
+load_button = NodePath("Panel/HBoxContainer/LoadButton")
 
-[node name="HBoxContainer" type="HBoxContainer" parent="." unique_id=1697879641]
+[node name="Panel" type="Panel" parent="." unique_id=1178714550]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="HBoxContainer" type="HBoxContainer" parent="Panel" unique_id=1697879641]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -20,53 +36,55 @@ grow_horizontal = 2
 grow_vertical = 2
 alignment = 1
 
-[node name="PrevButton" type="Button" parent="HBoxContainer" unique_id=806348556]
+[node name="PrevButton" type="Button" parent="Panel/HBoxContainer" unique_id=806348556]
 layout_mode = 2
 text = "Previous Page"
 
-[node name="PageCount" type="Label" parent="HBoxContainer" unique_id=2038342360]
+[node name="PageCount" type="Label" parent="Panel/HBoxContainer" unique_id=2038342360]
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 text = "1/1"
 horizontal_alignment = 1
 
-[node name="NextButton" type="Button" parent="HBoxContainer" unique_id=690276461]
+[node name="NextButton" type="Button" parent="Panel/HBoxContainer" unique_id=690276461]
 layout_mode = 2
 text = "Next Page"
 
-[node name="HBoxContainer" type="HBoxContainer" parent="HBoxContainer" unique_id=645195669]
+[node name="FRContainer" type="HBoxContainer" parent="Panel/HBoxContainer" unique_id=645195669]
 layout_mode = 2
 size_flags_vertical = 4
 
-[node name="HSlider" type="HSlider" parent="HBoxContainer/HBoxContainer" unique_id=1220768247]
+[node name="FRSlider" type="HSlider" parent="Panel/HBoxContainer/FRContainer" unique_id=1220768247]
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 size_flags_vertical = 4
 min_value = 1.0
-max_value = 10.0
+max_value = 12.0
 value = 1.0
 rounded = true
 tick_count = 1
 
-[node name="Label" type="Label" parent="HBoxContainer/HBoxContainer" unique_id=2030443127]
+[node name="Framerate" type="Label" parent="Panel/HBoxContainer/FRContainer" unique_id=2030443127]
+custom_minimum_size = Vector2(20, 0)
 layout_mode = 2
 text = "1"
+horizontal_alignment = 1
 
-[node name="PlayButton" type="Button" parent="HBoxContainer" unique_id=488848150]
+[node name="PlayButton" type="Button" parent="Panel/HBoxContainer" unique_id=488848150]
 layout_mode = 2
 text = "Play"
 
-[node name="SaveButton" type="Button" parent="HBoxContainer" unique_id=1671480537]
+[node name="SaveButton" type="Button" parent="Panel/HBoxContainer" unique_id=1671480537]
 layout_mode = 2
 text = "Save"
 
-[node name="LoadButton" type="Button" parent="HBoxContainer" unique_id=926630555]
+[node name="LoadButton" type="Button" parent="Panel/HBoxContainer" unique_id=926630555]
 layout_mode = 2
 text = "Load"
 
-[connection signal="pressed" from="HBoxContainer/PrevButton" to="." method="_on_prev_button_pressed"]
-[connection signal="pressed" from="HBoxContainer/NextButton" to="." method="_on_next_button_pressed"]
-[connection signal="value_changed" from="HBoxContainer/HBoxContainer/HSlider" to="." method="_on_slider_value_changed"]
-[connection signal="pressed" from="HBoxContainer/PlayButton" to="." method="_on_play_pressed"]
-[connection signal="pressed" from="HBoxContainer/SaveButton" to="." method="_on_save_button_pressed"]
-[connection signal="pressed" from="HBoxContainer/LoadButton" to="." method="_on_load_button_pressed"]
+[connection signal="pressed" from="Panel/HBoxContainer/PrevButton" to="." method="_on_prev_button_pressed"]
+[connection signal="pressed" from="Panel/HBoxContainer/NextButton" to="." method="_on_next_button_pressed"]
+[connection signal="value_changed" from="Panel/HBoxContainer/FRContainer/FRSlider" to="." method="_on_slider_value_changed"]
+[connection signal="pressed" from="Panel/HBoxContainer/PlayButton" to="." method="_on_play_pressed"]
+[connection signal="pressed" from="Panel/HBoxContainer/SaveButton" to="." method="_on_save_button_pressed"]
+[connection signal="pressed" from="Panel/HBoxContainer/LoadButton" to="." method="_on_load_button_pressed"]

--- a/views/editor/editor.gd
+++ b/views/editor/editor.gd
@@ -7,12 +7,18 @@ var current_tool: Tool
 
 @onready var canvas = $CanvasContainer/CanvasViewport/Canvas
 @onready var page_controls = $PageControls
+@onready var playback_manager = $PlaybackManager
 
 func _ready() -> void:
 	project = Project.new()
 
 	page_controls.attach_project(project)
 	canvas.attach_project(project)
+	playback_manager.attach_project(project)
+
+	page_controls.play_toggle.connect(
+		func(): playback_manager.is_playing = !playback_manager.is_playing
+		)
 
 	project.new_project(256, 192)
 
@@ -31,10 +37,3 @@ func _input(event: InputEvent) -> void:
 		elif event is InputEventMouseMotion:
 			if current_tool is Tool:
 				current_tool.on_pointer_move(canvas_pos, canvas)
-
-# Signal Forwarding
-func _next_page() -> void:
-	project.next_page(false)
-
-func _prev_page() -> void:
-	project.prev_page()

--- a/views/editor/editor.tscn
+++ b/views/editor/editor.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="Script" uid="uid://o1jeu63no2yo" path="res://views/editor/editor.gd" id="1_hjfbv"]
 [ext_resource type="PackedScene" uid="uid://ca1h0fih55p5l" path="res://system/canvas/canvas.tscn" id="2_uvf6n"]
 [ext_resource type="PackedScene" uid="uid://cj0amp2lxwem5" path="res://views/editor/containers/page_controls/page_controls.tscn" id="3_3o6tv"]
+[ext_resource type="Script" uid="uid://dg2xr82qtamwp" path="res://system/playback/playback_manager.gd" id="4_uvf6n"]
 
 [node name="Editor" type="Control" unique_id=1442565710]
 layout_mode = 3
@@ -30,13 +31,14 @@ render_target_update_mode = 4
 [node name="Canvas" parent="CanvasContainer/CanvasViewport" unique_id=502353309 instance=ExtResource("2_uvf6n")]
 
 [node name="PageControls" parent="." unique_id=352413597 instance=ExtResource("3_3o6tv")]
-custom_minimum_size = Vector2(0, 28)
+custom_minimum_size = Vector2(0, 32)
 layout_mode = 1
 anchors_preset = 12
 anchor_top = 1.0
 grow_vertical = 0
 
-[connection signal="framerate_change" from="PageControls" to="." method="_on_framerate_change"]
-[connection signal="load_call" from="PageControls" to="." method="_load_project"]
+[node name="PlaybackManager" type="Node" parent="." unique_id=1433802849]
+script = ExtResource("4_uvf6n")
+metadata/_custom_type_script = "uid://dg2xr82qtamwp"
+
 [connection signal="play_toggle" from="PageControls" to="." method="_play_toggle"]
-[connection signal="save_call" from="PageControls" to="." method="_save_project"]


### PR DESCRIPTION
Adds a PlaybackManager class into the project and updates the PageControls scene.
## Playback Manager
![Playback Manager in the Editor](https://github.com/user-attachments/assets/20b6c721-54b9-4c49-bcfe-dd5108b6f1d2)
A general class that handles the logic of playing back animation. Right now it simply loops. It is meant to be modular enough to be used in multiple views such as the current Editor or a potential Viewer.

## Page Controls
Editor's page controls node has been updated to be less of a passer of signals and has been rewired to work with the newer project organization. It also now exports the nodes to prevent potential null values when moved. There is additionally a transparent background now for improved contrast.