### PR TITLE
feat: Add editor menu shell

### DIFF
--- a/assets/base_ux/theme.tres
+++ b/assets/base_ux/theme.tres
@@ -52,6 +52,33 @@ anti_aliasing = false
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_m8jh7"]
 bg_color = Color(0.1497609, 0.28717783, 0.44712496, 0.39215687)
 
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ipy44"]
+bg_color = Color(1, 1, 1, 1)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_jbily"]
+content_margin_left = 8.0
+content_margin_top = 5.0
+content_margin_right = 8.0
+content_margin_bottom = 5.0
+bg_color = Color(0.49411765, 0.7411765, 1, 1)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_784td"]
+content_margin_left = 10.0
+content_margin_top = 5.0
+content_margin_right = 10.0
+content_margin_bottom = 5.0
+bg_color = Color(0, 0.5803922, 1, 1)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_0fy6x"]
+content_margin_left = 8.0
+content_margin_top = 5.0
+content_margin_right = 8.0
+content_margin_bottom = 5.0
+bg_color = Color(0, 0.21176471, 0.3882353, 1)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_cbw1g"]
+bg_color = Color(0.6784314, 0.6745098, 0.6627451, 1)
+
 [resource]
 Button/colors/font_color = Color(1, 1, 1, 1)
 Button/styles/disabled = SubResource("StyleBoxFlat_6j8ly")
@@ -61,3 +88,9 @@ Button/styles/normal = SubResource("StyleBoxFlat_31loe")
 Button/styles/pressed = SubResource("StyleBoxFlat_pchdo")
 ItemList/styles/panel = SubResource("StyleBoxFlat_xeq2n")
 Panel/styles/panel = SubResource("StyleBoxFlat_m8jh7")
+TabContainer/constants/side_margin = 0
+TabContainer/styles/panel = SubResource("StyleBoxFlat_ipy44")
+TabContainer/styles/tab_hovered = SubResource("StyleBoxFlat_jbily")
+TabContainer/styles/tab_selected = SubResource("StyleBoxFlat_784td")
+TabContainer/styles/tab_unselected = SubResource("StyleBoxFlat_0fy6x")
+TabContainer/styles/tabbar_background = SubResource("StyleBoxFlat_cbw1g")

--- a/system/canvas/canvas.gd
+++ b/system/canvas/canvas.gd
@@ -1,6 +1,8 @@
 class_name Canvas
 extends Node2D
 
+signal canvas_input(event: InputEventMouse)
+
 var _project: Project
 
 @onready var control_node: Control = $Control
@@ -73,3 +75,6 @@ func bake_page() -> void:
 		node.queue_free()
 
 	_project.get_current_page()
+
+func _on_gui_input(event: InputEvent) -> void:
+	canvas_input.emit(event)

--- a/system/canvas/canvas.tscn
+++ b/system/canvas/canvas.tscn
@@ -33,3 +33,5 @@ transparent_bg = true
 canvas_item_default_texture_filter = 0
 
 [node name="Bake" type="Node2D" parent="BakeViewport" unique_id=200955020]
+
+[connection signal="gui_input" from="Control" to="." method="_on_gui_input"]

--- a/views/editor/containers/edit_extras/edit_extras.gd
+++ b/views/editor/containers/edit_extras/edit_extras.gd
@@ -1,0 +1,33 @@
+class_name EditExtras
+extends Control
+
+@export var tab_container: TabContainer
+@export var anim_speed: float = 0.5
+
+var _project: Project
+
+func attach_project(project: Project):
+	_project = project
+	for node in tab_container.get_children():
+		if node.has_method("attach_project"):
+			node.attach_project(project)
+
+## Opens the extras panel.
+func open():
+	visible = true
+
+	var top = get_viewport_rect().size.y
+	position.y = top
+
+	var tween = create_tween().set_trans(Tween.TRANS_QUINT).set_ease(Tween.EASE_OUT)
+	tween.tween_property(self, "position:y", 0, anim_speed)
+
+## Closes and hides the extras panel.
+func close():
+	var top = get_viewport_rect().size.y
+
+	var tween = create_tween().set_trans(Tween.TRANS_QUINT).set_ease(Tween.EASE_OUT)
+	tween.tween_property(self, "position:y", top, anim_speed)
+	await tween.finished
+
+	visible = false

--- a/views/editor/containers/edit_extras/edit_extras.gd.uid
+++ b/views/editor/containers/edit_extras/edit_extras.gd.uid
@@ -1,0 +1,1 @@
+uid://c5sn6aanfjycw

--- a/views/editor/containers/edit_extras/edit_extras.tscn
+++ b/views/editor/containers/edit_extras/edit_extras.tscn
@@ -1,0 +1,68 @@
+[gd_scene format=3 uid="uid://d1bvrkbad6iok"]
+
+[ext_resource type="Script" uid="uid://c5sn6aanfjycw" path="res://views/editor/containers/edit_extras/edit_extras.gd" id="1_0ld5u"]
+[ext_resource type="PackedScene" uid="uid://dbwrjejtlwgk6" path="res://views/editor/containers/timeline_manager/timeline_manager.tscn" id="1_svsaf"]
+[ext_resource type="PackedScene" uid="uid://42u35o2152du" path="res://views/editor/containers/project_manager/project_manager.tscn" id="1_xequw"]
+[ext_resource type="PackedScene" uid="uid://cloa3c54w8ah8" path="res://views/editor/containers/tool_manager/tool_manager.tscn" id="2_0ld5u"]
+[ext_resource type="PackedScene" uid="uid://egoa0insqasw" path="res://views/editor/containers/sound_manager/sound_manager.tscn" id="4_5xylh"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_0ld5u"]
+bg_color = Color(1, 1, 1, 1)
+
+[node name="EditExtras" type="Control" unique_id=2042908143 node_paths=PackedStringArray("tab_container")]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_0ld5u")
+tab_container = NodePath("Panel/VBoxContainer/TabContainer")
+
+[node name="Panel" type="Panel" parent="." unique_id=1692244936]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_0ld5u")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Panel" unique_id=61122571]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 0
+
+[node name="TabContainer" type="TabContainer" parent="Panel/VBoxContainer" unique_id=1268311807]
+layout_mode = 2
+size_flags_vertical = 3
+current_tab = 0
+
+[node name="Project" parent="Panel/VBoxContainer/TabContainer" unique_id=1631588843 instance=ExtResource("1_xequw")]
+layout_mode = 2
+metadata/_tab_index = 0
+
+[node name="Tools" parent="Panel/VBoxContainer/TabContainer" unique_id=1657501930 instance=ExtResource("2_0ld5u")]
+visible = false
+layout_mode = 2
+metadata/_tab_index = 1
+
+[node name="Timeline" parent="Panel/VBoxContainer/TabContainer" unique_id=154136105 instance=ExtResource("1_svsaf")]
+visible = false
+layout_mode = 2
+metadata/_tab_index = 2
+
+[node name="Sounds" parent="Panel/VBoxContainer/TabContainer" unique_id=937746610 instance=ExtResource("4_5xylh")]
+visible = false
+layout_mode = 2
+metadata/_tab_index = 3
+
+[node name="CloseButton" type="Button" parent="Panel/VBoxContainer" unique_id=970103182]
+layout_mode = 2
+text = "Close"
+
+[connection signal="pressed" from="Panel/VBoxContainer/CloseButton" to="." method="close"]

--- a/views/editor/containers/page_controls/page_controls.gd
+++ b/views/editor/containers/page_controls/page_controls.gd
@@ -1,9 +1,11 @@
+class_name PageControls
 extends Node
+
+signal menu_toggle
 
 signal play_toggle
 
-signal load_call
-signal save_call
+@export var menu_button: Button
 
 @export var next_page_button: Button
 @export var page_count_label: Label
@@ -13,9 +15,6 @@ signal save_call
 @export var framerate_label: Label
 
 @export var play_button: Button
-
-@export var save_button: Button
-@export var load_button: Button
 
 var is_playing = false
 
@@ -50,8 +49,5 @@ func _on_slider_value_changed(value: float) -> void:
 	framerate_label.text = str(int(value))
 	_project.framerate = value
 
-func _on_save_button_pressed() -> void:
-	save_call.emit()
-
-func _on_load_button_pressed() -> void:
-	load_call.emit()
+func _on_menu_button_pressed() -> void:
+	menu_toggle.emit()

--- a/views/editor/containers/page_controls/page_controls.tscn
+++ b/views/editor/containers/page_controls/page_controls.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" uid="uid://fduhdjv3ekah" path="res://views/editor/containers/page_controls/page_controls.gd" id="1_8tmw1"]
 
-[node name="PageControls" type="Control" unique_id=352413597 node_paths=PackedStringArray("next_page_button", "page_count_label", "prev_page_button", "framerate_slider", "framerate_label", "play_button", "save_button", "load_button")]
+[node name="PageControls" type="Control" unique_id=352413597 node_paths=PackedStringArray("menu_button", "next_page_button", "page_count_label", "prev_page_button", "framerate_slider", "framerate_label", "play_button")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -10,14 +10,13 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_8tmw1")
-next_page_button = NodePath("Panel/HBoxContainer/NextButton")
-page_count_label = NodePath("Panel/HBoxContainer/PageCount")
-prev_page_button = NodePath("Panel/HBoxContainer/PrevButton")
-framerate_slider = NodePath("Panel/HBoxContainer/FRContainer/FRSlider")
-framerate_label = NodePath("Panel/HBoxContainer/FRContainer/Framerate")
-play_button = NodePath("Panel/HBoxContainer/PlayButton")
-save_button = NodePath("Panel/HBoxContainer/SaveButton")
-load_button = NodePath("Panel/HBoxContainer/LoadButton")
+menu_button = NodePath("Panel/ToolbarContents/MenuButton")
+next_page_button = NodePath("Panel/ToolbarContents/FrameControls/NextButton")
+page_count_label = NodePath("Panel/ToolbarContents/FrameControls/PageCount")
+prev_page_button = NodePath("Panel/ToolbarContents/FrameControls/PrevButton")
+framerate_slider = NodePath("Panel/ToolbarContents/FrameControls/FRContainer/FRSlider")
+framerate_label = NodePath("Panel/ToolbarContents/FrameControls/FRContainer/Framerate")
+play_button = NodePath("Panel/ToolbarContents/FrameControls/PlayButton")
 
 [node name="Panel" type="Panel" parent="." unique_id=1178714550]
 layout_mode = 1
@@ -27,34 +26,43 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Panel" unique_id=1697879641]
+[node name="ToolbarContents" type="HBoxContainer" parent="Panel" unique_id=296900544]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+
+[node name="MenuButton" type="Button" parent="Panel/ToolbarContents" unique_id=835707323]
+layout_mode = 2
+size_flags_horizontal = 0
+text = "Menu"
+
+[node name="FrameControls" type="HBoxContainer" parent="Panel/ToolbarContents" unique_id=1697879641]
+layout_mode = 2
+size_flags_horizontal = 3
 alignment = 1
 
-[node name="PrevButton" type="Button" parent="Panel/HBoxContainer" unique_id=806348556]
+[node name="PrevButton" type="Button" parent="Panel/ToolbarContents/FrameControls" unique_id=806348556]
 layout_mode = 2
 text = "Previous Page"
 
-[node name="PageCount" type="Label" parent="Panel/HBoxContainer" unique_id=2038342360]
+[node name="PageCount" type="Label" parent="Panel/ToolbarContents/FrameControls" unique_id=2038342360]
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 text = "1/1"
 horizontal_alignment = 1
 
-[node name="NextButton" type="Button" parent="Panel/HBoxContainer" unique_id=690276461]
+[node name="NextButton" type="Button" parent="Panel/ToolbarContents/FrameControls" unique_id=690276461]
 layout_mode = 2
 text = "Next Page"
 
-[node name="FRContainer" type="HBoxContainer" parent="Panel/HBoxContainer" unique_id=645195669]
+[node name="FRContainer" type="HBoxContainer" parent="Panel/ToolbarContents/FrameControls" unique_id=645195669]
 layout_mode = 2
 size_flags_vertical = 4
 
-[node name="FRSlider" type="HSlider" parent="Panel/HBoxContainer/FRContainer" unique_id=1220768247]
+[node name="FRSlider" type="HSlider" parent="Panel/ToolbarContents/FrameControls/FRContainer" unique_id=1220768247]
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 size_flags_vertical = 4
@@ -64,27 +72,18 @@ value = 1.0
 rounded = true
 tick_count = 1
 
-[node name="Framerate" type="Label" parent="Panel/HBoxContainer/FRContainer" unique_id=2030443127]
+[node name="Framerate" type="Label" parent="Panel/ToolbarContents/FrameControls/FRContainer" unique_id=2030443127]
 custom_minimum_size = Vector2(20, 0)
 layout_mode = 2
 text = "1"
 horizontal_alignment = 1
 
-[node name="PlayButton" type="Button" parent="Panel/HBoxContainer" unique_id=488848150]
+[node name="PlayButton" type="Button" parent="Panel/ToolbarContents/FrameControls" unique_id=488848150]
 layout_mode = 2
 text = "Play"
 
-[node name="SaveButton" type="Button" parent="Panel/HBoxContainer" unique_id=1671480537]
-layout_mode = 2
-text = "Save"
-
-[node name="LoadButton" type="Button" parent="Panel/HBoxContainer" unique_id=926630555]
-layout_mode = 2
-text = "Load"
-
-[connection signal="pressed" from="Panel/HBoxContainer/PrevButton" to="." method="_on_prev_button_pressed"]
-[connection signal="pressed" from="Panel/HBoxContainer/NextButton" to="." method="_on_next_button_pressed"]
-[connection signal="value_changed" from="Panel/HBoxContainer/FRContainer/FRSlider" to="." method="_on_slider_value_changed"]
-[connection signal="pressed" from="Panel/HBoxContainer/PlayButton" to="." method="_on_play_pressed"]
-[connection signal="pressed" from="Panel/HBoxContainer/SaveButton" to="." method="_on_save_button_pressed"]
-[connection signal="pressed" from="Panel/HBoxContainer/LoadButton" to="." method="_on_load_button_pressed"]
+[connection signal="pressed" from="Panel/ToolbarContents/MenuButton" to="." method="_on_menu_button_pressed"]
+[connection signal="pressed" from="Panel/ToolbarContents/FrameControls/PrevButton" to="." method="_on_prev_button_pressed"]
+[connection signal="pressed" from="Panel/ToolbarContents/FrameControls/NextButton" to="." method="_on_next_button_pressed"]
+[connection signal="value_changed" from="Panel/ToolbarContents/FrameControls/FRContainer/FRSlider" to="." method="_on_slider_value_changed"]
+[connection signal="pressed" from="Panel/ToolbarContents/FrameControls/PlayButton" to="." method="_on_play_pressed"]

--- a/views/editor/containers/project_manager/project_manager.tscn
+++ b/views/editor/containers/project_manager/project_manager.tscn
@@ -1,0 +1,9 @@
+[gd_scene format=3 uid="uid://42u35o2152du"]
+
+[node name="Project" type="Control" unique_id=1631588843]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2

--- a/views/editor/containers/sound_manager/sound_manager.tscn
+++ b/views/editor/containers/sound_manager/sound_manager.tscn
@@ -1,0 +1,9 @@
+[gd_scene format=3 uid="uid://egoa0insqasw"]
+
+[node name="Sounds" type="Control" unique_id=937746610]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2

--- a/views/editor/containers/timeline_manager/timeline_manager.tscn
+++ b/views/editor/containers/timeline_manager/timeline_manager.tscn
@@ -1,0 +1,9 @@
+[gd_scene format=3 uid="uid://dbwrjejtlwgk6"]
+
+[node name="Timeline" type="Control" unique_id=154136105]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2

--- a/views/editor/containers/tool_manager/tool_manager.tscn
+++ b/views/editor/containers/tool_manager/tool_manager.tscn
@@ -1,0 +1,9 @@
+[gd_scene format=3 uid="uid://cloa3c54w8ah8"]
+
+[node name="Tools" type="Control" unique_id=1657501930]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2

--- a/views/editor/editor.gd
+++ b/views/editor/editor.gd
@@ -1,13 +1,14 @@
 extends Node
 
+@export var canvas: Canvas
+@export var page_controls: PageControls
+@export var playback_manager: PlaybackManager
+@export var edit_extras: EditExtras
+
 var project: Project
 var current_page: Page
 
 var current_tool: Tool
-
-@onready var canvas = $CanvasContainer/CanvasViewport/Canvas
-@onready var page_controls = $PageControls
-@onready var playback_manager = $PlaybackManager
 
 func _ready() -> void:
 	project = Project.new()
@@ -15,7 +16,11 @@ func _ready() -> void:
 	page_controls.attach_project(project)
 	canvas.attach_project(project)
 	playback_manager.attach_project(project)
+	edit_extras.attach_project(project)
 
+	canvas.canvas_input.connect(_handle_canvas_input)
+
+	page_controls.menu_toggle.connect(edit_extras.open)
 	page_controls.play_toggle.connect(
 		func(): playback_manager.is_playing = !playback_manager.is_playing
 		)
@@ -24,7 +29,7 @@ func _ready() -> void:
 
 	current_tool = Brush.new() # Placeholder for now.
 
-func _input(event: InputEvent) -> void:
+func _handle_canvas_input(event: InputEvent) -> void:
 	if event is InputEventMouse:
 		var canvas_pos = canvas.dynamic_node.get_local_mouse_position()
 		if event is InputEventMouseButton:

--- a/views/editor/editor.tscn
+++ b/views/editor/editor.tscn
@@ -3,9 +3,10 @@
 [ext_resource type="Script" uid="uid://o1jeu63no2yo" path="res://views/editor/editor.gd" id="1_hjfbv"]
 [ext_resource type="PackedScene" uid="uid://ca1h0fih55p5l" path="res://system/canvas/canvas.tscn" id="2_uvf6n"]
 [ext_resource type="PackedScene" uid="uid://cj0amp2lxwem5" path="res://views/editor/containers/page_controls/page_controls.tscn" id="3_3o6tv"]
+[ext_resource type="PackedScene" uid="uid://d1bvrkbad6iok" path="res://views/editor/containers/edit_extras/edit_extras.tscn" id="4_mq76j"]
 [ext_resource type="Script" uid="uid://dg2xr82qtamwp" path="res://system/playback/playback_manager.gd" id="4_uvf6n"]
 
-[node name="Editor" type="Control" unique_id=1442565710]
+[node name="Editor" type="Control" unique_id=1442565710 node_paths=PackedStringArray("canvas", "page_controls", "playback_manager", "edit_extras")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -13,6 +14,10 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_hjfbv")
+canvas = NodePath("CanvasContainer/CanvasViewport/Canvas")
+page_controls = NodePath("PageControls")
+playback_manager = NodePath("PlaybackManager")
+edit_extras = NodePath("EditExtras")
 
 [node name="CanvasContainer" type="SubViewportContainer" parent="." unique_id=1491532430]
 layout_mode = 1
@@ -37,8 +42,10 @@ anchors_preset = 12
 anchor_top = 1.0
 grow_vertical = 0
 
+[node name="EditExtras" parent="." unique_id=2042908143 instance=ExtResource("4_mq76j")]
+visible = false
+layout_mode = 1
+
 [node name="PlaybackManager" type="Node" parent="." unique_id=1433802849]
 script = ExtResource("4_uvf6n")
 metadata/_custom_type_script = "uid://dg2xr82qtamwp"
-
-[connection signal="play_toggle" from="PageControls" to="." method="_play_toggle"]


### PR DESCRIPTION
![Recording of the extras menu in usage](https://github.com/user-attachments/assets/c4cdb208-6539-4c31-ad74-7c05bffebdec)
Adds a new extras menu to the editor. This will hold the more advanced options that are not nearly as needed in the canvas view. Shell scenes of some of those menus are also made and are placed inside of the tab container.