### PR TITLE
Update canvas.gd

### DIFF
--- a/system/canvas/canvas.gd
+++ b/system/canvas/canvas.gd
@@ -96,7 +96,7 @@ func bake_page() -> void:
 				c.g /= c.a
 				c.b /= c.a
 			image_to_bake.set_pixel(x, y, c)
-	
+
 	var layer_image = current_page.layers[current_layer]
 	layer_image.blend_rect(
 		image_to_bake, Rect2(Vector2.ZERO, image_to_bake.get_size()), Vector2.ZERO

--- a/system/canvas/canvas.gd
+++ b/system/canvas/canvas.gd
@@ -70,19 +70,34 @@ func bake_page() -> void:
 	var current_layer = _project._current_layer + 1
 
 	bake_viewport.size = Vector2(_project.width, _project.height)
+	bake_viewport.render_target_clear_mode = SubViewport.CLEAR_MODE_ALWAYS
+	bake_viewport.transparent_bg = true
 
 	# Preventing the odd flicker between render and baking.
 	for node in dynamic_node.get_children():
 		var new_node = node.duplicate()
 		bake_node.add_child(new_node)
 
-		# Taking the snapshot of our dynamic node.
-		bake_viewport.render_target_update_mode = SubViewport.UPDATE_ONCE
-		await RenderingServer.frame_post_draw
+	# Taking the snapshot of our dynamic node.
+	bake_viewport.render_target_update_mode = SubViewport.UPDATE_ONCE
+	await RenderingServer.frame_post_draw
 
 	# Baking ontop of the existing layer.
+
 	var texture_to_bake = bake_viewport.get_texture()
 	var image_to_bake = texture_to_bake.get_image()
+
+	# Convert premultiply RGB to normal RGB
+	# Reference: https://forum.godotengine.org/t/partial-transparency-blended-with-black-in-screenshot-images/128560
+	for y in image_to_bake.get_height():
+		for x in image_to_bake.get_width():
+			var c = image_to_bake.get_pixel(x, y)
+			if c.a > 0.0:
+				c.r /= c.a
+				c.g /= c.a
+				c.b /= c.a
+			image_to_bake.set_pixel(x, y, c)
+	
 
 	var layer_image = current_page.layers[current_layer]
 	layer_image.blend_rect(

--- a/system/canvas/canvas.gd
+++ b/system/canvas/canvas.gd
@@ -88,7 +88,6 @@ func bake_page() -> void:
 	var image_to_bake = texture_to_bake.get_image()
 
 	# Convert premultiply RGB to normal RGB
-	# Reference: https://forum.godotengine.org/t/partial-transparency-blended-with-black-in-screenshot-images/128560
 	for y in image_to_bake.get_height():
 		for x in image_to_bake.get_width():
 			var c = image_to_bake.get_pixel(x, y)
@@ -98,7 +97,6 @@ func bake_page() -> void:
 				c.b /= c.a
 			image_to_bake.set_pixel(x, y, c)
 	
-
 	var layer_image = current_page.layers[current_layer]
 	layer_image.blend_rect(
 		image_to_bake, Rect2(Vector2.ZERO, image_to_bake.get_size()), Vector2.ZERO


### PR DESCRIPTION
Remove the gray boundary of the brush caused by incorrectly rendering the alpha channel.

SubViewport stores pixels infor like that:
rgb = original_rgb * alpha
a = alpha

So the alpha channel was not rendered correctly.

A reverse function is needed to make the brush actually transparent instead of gray with various shades.

Reference:
https://forum.godotengine.org/t/partial-transparency-blended-with-black-in-screenshot-images/128560